### PR TITLE
Fix the bot telling a ticket is already opened when trying to open a ticket when bot cannot DM us

### DIFF
--- a/src/main/java/yt/graven/gravensupport/commands/ticket/Ticket.java
+++ b/src/main/java/yt/graven/gravensupport/commands/ticket/Ticket.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.requests.ErrorResponse;
@@ -107,9 +108,7 @@ public class Ticket {
 
         ErrorHandler errorHandler = new ErrorHandler()
             .ignore(ErrorResponse.UNKNOWN_MESSAGE)
-            .handle(ErrorResponse.CANNOT_SEND_TO_USER,
-                exception -> TMessage.from(embeds.error("Impossible d'envoyer un message privé à cet utilisateur!")
-                        .build()).sendMessage(channel).queue());
+            .handle(ErrorResponse.CANNOT_SEND_TO_USER, exception -> handleUnableToDmUser(channel));
 
         from.openPrivateChannel()
             .complete()
@@ -380,5 +379,14 @@ public class Ticket {
 
             to.delete().queue((v1) -> ticketManager.remove(from));
         });
+    }
+
+    private void handleUnableToDmUser(MessageChannel channel) {
+        ticketManager.remove(from);
+
+        String errorMessage = "Impossible d'envoyer un message privé à cet utilisateur!";
+        MessageEmbed embed = embeds.error(errorMessage).build();
+
+        TMessage.from(embed).sendMessage(channel).queue();
     }
 }

--- a/src/main/java/yt/graven/gravensupport/commands/ticket/create/TicketCommand.java
+++ b/src/main/java/yt/graven/gravensupport/commands/ticket/create/TicketCommand.java
@@ -59,7 +59,7 @@ public class TicketCommand implements ICommand {
             return;
         }
 
-        ticketManager.create(event.getAuthor()).proposeOpening();
+        ticketManager.create(event.getAuthor()).proposeOpening(event.getChannel());
     }
 
     private void runWithSelectedUser(MessageReceivedEvent event, String[] args) throws TicketException, IOException {


### PR DESCRIPTION
## Bug description

When trying to open a ticket using `!new`, the bot ignores the fact that it can DM you or not, and considers you have received the message anyway.
It then considers the ticket to be opened while it is not.

This is fixed now, but bug #13 still exists.

Fixes #10