### PR TITLE
Fix forced ticket not opened when user block PV

### DIFF
--- a/src/main/java/yt/graven/gravensupport/commands/ticket/Ticket.java
+++ b/src/main/java/yt/graven/gravensupport/commands/ticket/Ticket.java
@@ -170,7 +170,7 @@ public class Ticket {
                     .setColor(0x48dbfb)
                     .build())
                 .sendMessage(channel)
-                .complete();
+                .queue();
             TMessage.create()
                 .setEmbeds(new EmbedBuilder()
                     .setTitle("Sélectionnez le premier message à envoyer :")
@@ -186,7 +186,7 @@ public class Ticket {
                 .deletable()
                 .build()
                 .sendMessage(channel)
-                .complete();
+                .queue();
         }
 
         TextChannel ticketChannel =

--- a/src/main/java/yt/graven/gravensupport/commands/ticket/create/TicketCommand.java
+++ b/src/main/java/yt/graven/gravensupport/commands/ticket/create/TicketCommand.java
@@ -123,7 +123,7 @@ public class TicketCommand implements ICommand {
 
 
         Ticket ticket = ticketManager.create(user);
-        ticket.forceOpening(event.getAuthor());
+        ticket.forceOpening(event.getAuthor(), event.getChannel());
 
         embeds
             .successMessage(String.format(

--- a/src/main/java/yt/graven/gravensupport/utils/messages/TMessage.java
+++ b/src/main/java/yt/graven/gravensupport/utils/messages/TMessage.java
@@ -4,11 +4,11 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.Component;
 import net.dv8tion.jda.api.interactions.components.ItemComponent;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
+import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import org.jetbrains.annotations.NotNull;
 
@@ -94,16 +94,17 @@ public class TMessage {
         return action;
     }
 
-    public MessageAction sendMessage(User user) {
-        MessageAction action = user.openPrivateChannel()
-            .complete()
-            .sendMessage(this.build());
-        for (File file : files) {
-            action = action.addFile(file);
-            file.delete();
-        }
-        files = new ArrayList<>();
-        return action;
+    public RestAction<Message> sendMessage(User user) {
+        return user.openPrivateChannel()
+            .flatMap(channel -> {
+                MessageAction action = channel.sendMessage(this.build());
+                for (File file : files) {
+                    action = action.addFile(file);
+                    file.delete();
+                }
+                files = new ArrayList<>();
+                return action;
+            });
     }
 
     public static class TActionRow {


### PR DESCRIPTION
## Bug description

When trying force to open a ticket using `!new %id%`, the bot ignores the fact that it can DM you or not, and considers user have received the message anyway.
It then considers the ticket to be opened while it is not.

Related #14 
Fixes #19